### PR TITLE
Multi init bug

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Ironseed-py.iml
+++ b/.idea/Ironseed-py.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (Ironseed-py) (2)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Ironseed-py.iml" filepath="$PROJECT_DIR$/.idea/Ironseed-py.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/global_constants.py
+++ b/global_constants.py
@@ -7,16 +7,16 @@ Note:  The constant bit refers to the naming...
 """
 import pygame, os
 
+
+# Simple objects is declared and initialized here,
+# class object types is declared here and initialized in the init method.
+
 size = width, height = 640, 480  # screen dimensions
 #  Planet texture constants.
 planetHeight = 240  # 120
 planetWidth = 480  # 240
 #  It's certainly not a lively python...
 version = "IronPython 0.02 - Frigid Snake Alpha"
-
-#  Initialise music system and pygame
-pygame.mixer.pre_init(44100, -16, 2, 2048)
-pygame.init()
 
 #  Colours
 WHITE = (255, 255, 255)
@@ -36,9 +36,7 @@ TECH3 = (150, 150, 0)
 TECH4 = (200, 200, 0)
 TECH5 = (250, 250, 0)
 
-# Note: Font should resize according to resolution, but logic needed.
-#  Fonts:  this is a temporary google font, get it from them.
-font = pygame.font.Font(os.path.join('Fonts', 'Inconsolata-ExtraBold.ttf'), 14)
+font: object
 offset = 15  # for this font.
 
 #  Totals for items
@@ -60,5 +58,20 @@ eventFlags = []  #  Having as event list of flags makes things much simpler
 
 systemsVisited = []
 
-starDate = [2, 3, 3784, 8, 75]  #M,D,Y,H,M, Default entry here is for new game.
-gameDate = "Placeholder"  #  The game time needs to be accessible everywhere.
+starDate = [2, 3, 3784, 8, 75]  # M,D,Y,H,M, Default entry here is for new game.
+gameDate: object  #  The game time needs to be accessible everywhere.
+
+
+# Class objects need a separate init function
+def init(init_game_date):
+    #  Initialise music system and pygame
+    pygame.mixer.pre_init(44100, -16, 2, 2048)
+    pygame.init()
+    global font
+    # Note: Font should resize according to resolution, but logic needed.
+    #  Fonts:  this is a temporary google font, get it from them.
+    font = pygame.font.Font(os.path.join('Fonts', 'Inconsolata-ExtraBold.ttf'), 14)
+
+    # Initialise game objects
+    global gameDate
+    gameDate = init_game_date

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -72,8 +72,11 @@ def colourLine(length, colour):
 #  Rounded indicates if the end of the bar needs to be drawn as
 #  half a hemesphere with Height diameter.
 #  Returns a pygame surface with the required elements added.
-def createBar(tupleList=[], length=0, height=int((g.height/320)*2), rounded=False):
-    
+def createBar(tupleList=None, length=0, height=None, rounded=False):
+    if height is None:
+        height = int((g.height / 320) * 2)
+    if tupleList is None:
+        tupleList = []
     bar = pygame.Surface((length, height))
     bar.set_colorkey(g.BLACK)
     barArray = pygame.PixelArray(bar)

--- a/ironSeed.py
+++ b/ironSeed.py
@@ -15,29 +15,27 @@ import global_constants as g
 import helper_functions as h
 
 class IronSeed(object):
-    
+
     def __init__(self):
-        
-        self.state = 3  # Initilise with intro set, normally 3.
+
+        self.state = 3  # Initialise with intro set, normally 3.
 
         self.creditText = ["1994 Channel 7, Destiny: Virtual",
-                          "Released Under GPL V3.0 in 2013 by Jeremy D Stanton of IronSeed.net",
-                          "2013 y-salnikov - Converted IronSeed to FreePascal and GNU/Linux",
-                          "2016 Nuke Bloodaxe - Pascal Code Tidying/Prep",
-                          "2020 Nuke Bloodaxe - Complete Python Refactor/Rewrite",
-                          "All rights reserved."]
+                           "Released Under GPL V3.0 in 2013 by Jeremy D Stanton of IronSeed.net",
+                           "2013 y-salnikov - Converted IronSeed to FreePascal and GNU/Linux",
+                           "2016 Nuke Bloodaxe - Pascal Code Tidying/Prep",
+                           "2020 Nuke Bloodaxe - Complete Python Refactor/Rewrite",
+                           "All rights reserved."]
         self.versionText = ["Ironseed", g.version]
-        
+
         # Set Window version and Display surface
         print("Initialise Screen.")
         self.displaySurface = pygame.display.set_mode(g.size)
         pygame.display.set_caption(self.versionText[0]+' '+self.versionText[1])
-        
-        # Initialise game objects
-        print("Initilising IronSeed Game Time")
-        g.starDate = [2, 3, 3784, 8, 75] # M,D,Y,H,M.
-        g.gameDate = h.IronSeedTime()
-        
+
+        # init globals
+        g.init(h.IronSeedTime())
+
         # Populate Item dictionaries
         print("Loading Items: ", end='')
         items.loadItemData()
@@ -73,7 +71,7 @@ class IronSeed(object):
         print("Game Generator Objects: ", end='')
         self.generator = gen.Generator(self.ship, self.crew)  # Settings at new-game state.
         print("complete.")
-        print("Commnications System Objects: ", end='')
+        print("Communications System Objects: ", end='')
         self.crewCom = crewC.crewComm(self.crew)  # Needs to have crew data set.
         print("complete.")
         print("Planet Scanner Objects: ", end='')
@@ -97,9 +95,9 @@ class IronSeed(object):
         print("Creating Main Menu: ", end='')
         self.mainMenu = mainMenu.MainMenu()
         print("complete.")
-        
+
         # Note:  While in Alpha, the below state list is not exhaustive.
-        
+
         self.states = {1:self.generator.update,  # The crew + ship selection system.
                        2:self.mainMenu.update,  # Main menu.
                        3:self.intro.update,  # Game Intro - quite useful for testing.
@@ -118,7 +116,7 @@ class IronSeed(object):
                        16: "Creation",  # really item assembly/disassembly.
                        17: "Sector Map" # Inter-Sector travel.
                        }
-        
+
         self.interactive = {1:self.generator.interact,
                             2:self.mainMenu.interact,
                             3:self.intro.interact,
@@ -152,20 +150,26 @@ class IronSeed(object):
 
         # enter main state and logic loop.
         while 1:
-            
+
             for evt in pygame.event.get():
-                
+
                 if evt.type == pygame.QUIT:
-                    
+
                     pygame.quit()
                     sys.exit()
-                    
+
                 # Handle mouse input.
                 elif evt.type == pygame.MOUSEBUTTONDOWN:
-                    
+
                     self.state = self.interactive[self.state](evt.button)
-                    
+
             g.gameDate.update()  #  Update game time in "realtime"
             self.state = self.states[self.state](self.displaySurface)
             # self.state(self.displaySurface)
             pygame.display.update()
+
+
+if __name__ == "__main__":
+    game = IronSeed()
+    game.main_loop()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-#
 ####### requirements.txt #######
-#
+
 ###### Requirements without Version Specifiers ######
 pygame
 #io
@@ -10,23 +9,20 @@ pygame
 #sys
 #time
 numpy
-#
+
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 #docopt == 0.6.1             # Version Matching. Must be version 0.6.1
 #keyring >= 4.1.1            # Minimum version 4.1.1
 #coverage != 3.5             # Version Exclusion. Anything except version 3.5
 #Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
-#
-python >= 3.0
+
 ###### Refer to other requirements files ######
 #-r other-requirements.txt
-#
-#
 ###### A particular file ######
 #./downloads/numpy-1.9.2-cp34-none-win32.whl
 #http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
-#
+
 ###### Additional Requirements without Version Specifiers ######
 #   Same as 1st section, just here to show that you can put things in any order.
 #rejected


### PR DESCRIPTION
There was a bug that caused the process to hang.
It was hard to debug as the program apparently ran to end, I tried adding a final print statement, and it was printed. So the process should exit. But it did not.

I early suspected some background task of pygame to be the culprit.

I narrowed the cause it down to the pygame.init being called multiply times. This happens because there is a call to this pygame.init function in the root scope of global_constants.py, causing this function to be called each time this file is imported by any other file.
I also found that this error was not consistent, some times it would exit fine with no delay and other times just hang. I also found that if commented out some of the imports, that also imported global_constants, thereby reducing the number of times that pygame.init was called, I saw a drop in the number times it would hang, confirming my suspicion that this was triggering some race condition in the pygame background tasks.

Solution: I moved the initialization  of the non-primitive types inside an init function, including this call to pygame,init(). So now the pygame.init() is only called when this function is explicitly called. Also added the call to this init() to ironSeed.py.

Note: I had to inject the h.IronSeedTime object through this call to, as calling it directly from within globals would not work as it would create a circular import loop.

@Nuke Bloodaxe if you don't like the pyCharm ide just leave out the .idea folder in the pull request merge.
